### PR TITLE
Fix bug table avec underscore dans le nom lors de jointure

### DIFF
--- a/Manager.php
+++ b/Manager.php
@@ -636,7 +636,8 @@ abstract class Manager {
                     $fields .= ',';
                 }
                 if (!array_key_exists($ta_field['table'],$ta_tables)) {
-                    $classe = 'src\manager\\' . ucfirst($ta_field['table']).'Manager';
+                    $table = preg_replace('/ /','',ucwords(preg_replace('/_/',' ',$ta_field['table'])));
+                    $classe = 'src\manager\\' . $table.'Manager';
                     $obj = new $classe($this->db);
                     $obj->recordFields();
                     $ta_tables = $this->fieldsList();


### PR DESCRIPTION
Pour respecter la nomenclature des noms des Models et Managers lors des requêtes on doit transformer "test_table" en "TestTable" et non en "Test_table" comme c'était le cas pour les jointures avant ce patch.