### PR TITLE
Bug bind sequences avec WHEREx > 9

### DIFF
--- a/Manager.php
+++ b/Manager.php
@@ -781,7 +781,7 @@ abstract class Manager {
                 }
                 foreach ($ta_where as $where) {
                     $count++;
-                    $chaine_where = str_replace('WHERE'.$count, $where, $chaine_where);
+                    $chaine_where = preg_replace('#WHERE' . $count . '\b#', $where, $chaine_where);
                 }
                 $requete .= $chaine_where;
             }


### PR DESCRIPTION
Lors du replace des WHEREn dans la sequence, bug si n > 9. Le replace remplaçait WHERE1x par la valeur de WHERE1 etc...