### PR TITLE
V3.0.2 — Corrections post-revue

### DIFF
--- a/DbConnect.php
+++ b/DbConnect.php
@@ -140,12 +140,12 @@
             return $this->_dbCrypt;
         }
         
-        function connect(): void
+        function connect(string $charset = 'utf8'): void
         {
             try {
-                $dsn = $this->_type . ':host=' . $this->_host . ';dbname=' . $this->_database . ';charset=utf8';
+                $dsn = $this->_type . ':host=' . $this->_host . ';dbname=' . $this->_database . ';charset=' . $charset;
                 $options = array(
-                    PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8',
+                    PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES ' . $charset . ' COLLATE ' . $charset . '_unicode_ci',
                 );
                 
                 $this->_pdo = new PDO($dsn, $this->_user, $this->_pass, $options);

--- a/Manager.php
+++ b/Manager.php
@@ -43,7 +43,7 @@
         protected array $_encryptedFields = [];
         protected $crypt;
         /** @var string|null Contenu texte erreur. */
-        protected ?string $errorTxt;
+        protected ?string $errorTxt = null;
         /** @var string Contenu texte du debug. */
         protected string $debugTxt = '';
         /** @var array Liste des champs cryptés qui doivent rester triable. */

--- a/Manager.php
+++ b/Manager.php
@@ -12,8 +12,10 @@
     use processid\manager\attributes\ID;
     use processid\manager\attributes\Table;
     use processid\manager\enum\QueryOperator;
+    use processid\manager\exception\ManagerNotFoundException;
     use ReflectionClass;
     use RuntimeException;
+    use Throwable;
     
     /**
      * Classe résponsable de l'interaction avec la base de données.
@@ -95,9 +97,9 @@
         /**
          * Récupère le message d'erreur s'il y en a lors d'une intéraction avec la base de données.
          *
-         * @return string
+         * @return ?string
          */
-        public function errorTxt(): string
+        public function errorTxt(): ?string
         {
             return $this->errorTxt;
         }
@@ -272,7 +274,7 @@
                     }, $fieldsTable);
                 }
                 
-                $request = $this->contruct_request($arg, false);
+                $request = $this->contruct_request($arg);
                 $this->setDebugTxt($request, true);
                 
                 if (false === ($stmt = $this->db->pdo()->prepare($request))) {
@@ -314,7 +316,6 @@
                 }
                 
                 $this->_bindParamsStmt($stmt);
-                $stmt->execute();
                 
                 if (false === $stmt->execute()) {
                     $this->setErrorTxt('Erreur dans countBy():execute() - ' . implode(' - ', $this->db->pdo()->errorInfo()) . ' - ' . $request);
@@ -1203,6 +1204,8 @@
          * @param bool $subRequest Indique si c'est une sous requête et dans ce cas ne pas réinitialiser les variables de construction de requête.
          *
          * @return string Requête préparée SQL.
+         *
+         * @throws ManagerNotFoundException
          */
         private function contruct_request(array $arg = [], bool $subRequest = false): string
         {
@@ -1229,12 +1232,8 @@
                     $fields .= ($fields != '' ? ',' : '');
                     
                     if (!array_key_exists($ta_field['table'], $ta_tables)) {
-                        $table = preg_replace('/ /', '', ucwords(preg_replace('/_/', ' ', $ta_field['table'])));
-                        $classe = 'src\manager\\' . $table . 'Manager';
-                        $obj = new $classe($this->db);
-                        $obj->recordFields();
+                        $this->recordTableField($ta_field['table']);
                         $ta_tables = $this->fieldsList();
-                        unset($obj);
                     }
                     if ($ta_field['field'] == '*') {
                         $fields .= '*';
@@ -1265,28 +1264,16 @@
             if (array_key_exists('join', $arg) && is_array($arg['join']) && count($arg['join'])) {
                 foreach ($arg['join'] as $ta_join) {
                     if (!array_key_exists($ta_join['table'], $ta_tables)) {
-                        $table = preg_replace('/ /', '', ucwords(preg_replace('/_/', ' ', $ta_join['table'])));
-                        $classe = 'src\manager\\' . $table . 'Manager';
-                        $obj = new $classe($this->db);
-                        $obj->recordFields();
+                        $this->recordTableField($ta_join['table']);
                         $ta_tables = $this->fieldsList();
-                        unset($obj);
                     }
                     if (!array_key_exists($ta_join['on']['table1'], $ta_tables)) {
-                        $table = preg_replace('/ /', '', ucwords(preg_replace('/_/', ' ', $ta_join['on']['table1'])));
-                        $classe = 'src\manager\\' . $table . 'Manager';
-                        $obj = new $classe($this->db);
-                        $obj->recordFields();
+                        $this->recordTableField($ta_join['on']['table1']);
                         $ta_tables = $this->fieldsList();
-                        unset($obj);
                     }
                     if (!array_key_exists($ta_join['on']['table2'], $ta_tables)) {
-                        $table = preg_replace('/ /', '', ucwords(preg_replace('/_/', ' ', $ta_join['on']['table2'])));
-                        $classe = 'src\manager\\' . $table . 'Manager';
-                        $obj = new $classe($this->db);
-                        $obj->recordFields();
+                        $this->recordTableField($ta_join['on']['table2']);
                         $ta_tables = $this->fieldsList();
-                        unset($obj);
                     }
                     if (!array_key_exists($ta_join['on']['table1'], $ta_tables)) {
                         trigger_error('La table : ' . $ta_join['on']['table1'] . ' est introuvable', E_USER_ERROR);
@@ -1323,12 +1310,8 @@
             $ta_where = [];
             foreach ($arg['search'] as $ta_search) {
                 if (!array_key_exists($ta_search['table'], $ta_tables)) {
-                    $table = preg_replace('/ /', '', ucwords(preg_replace('/_/', ' ', $ta_search['table'])));
-                    $classe = 'src\manager\\' . $table . 'Manager';
-                    $obj = new $classe();
-                    $obj->recordFields();
+                    $this->recordTableField($ta_search['table']);
                     $ta_tables = $this->fieldsList();
-                    unset($obj);
                 }
                 if (!array_key_exists($ta_search['field'], $ta_tables[$ta_search['table']])) {
                     trigger_error('Le champ : ' . $ta_search['field'] . ' est introuvable dans la table : ' . $ta_search['table'], E_USER_ERROR);
@@ -1466,41 +1449,6 @@
                         $maWhere .= ')';
                         $ta_where[] = $maWhere;
                     }
-                } elseif ($ta_search['operator'] == QueryOperator::FULLTEXT_MATCH_AGAINST->value || $ta_search['operator'] == QueryOperator::FULLTEXT_MATCH_AGAINST_BOOLEAN->value) {
-                    $this->_ta_bind[$this->_count_bind] = [];
-                    $this->_ta_bind[$this->_count_bind]['table'] = $ta_search['table'];
-                    if (preg_match('#^id[0-9]{1,}$#', $ta_search['value'])) {
-                        $this->_ta_bind[$this->_count_bind]['field'] = $this->tableIdField();
-                        $this->_ta_bind[$this->_count_bind]['value'] = (int)trim(substr($ta_search['value'], 2));
-                        $ta_where[] = $ta_search['table'] . '.' . $this->tableIdField() . '=:bind' . $this->_count_bind++;
-                    } else {
-                        $search_value = trim($ta_search['value']);
-                        
-                        // Suppression des caractères spéciaux
-                        $processed_value = preg_replace('/[^\p{L}\p{N}\s]+/u', ' ', $search_value);
-                        // Normalisation des espaces multiples
-                        $processed_value = preg_replace("/[[:space:]]{2,}/u", " ", $processed_value);
-                        
-                        $arrayRec = explode(" ", $processed_value);
-                        $match = '';
-                        
-                        foreach ($arrayRec as $mot) {
-                            $mot = trim($mot);
-                            if (empty($mot)) {
-                                continue;
-                            }
-                            
-                            $match .= " +$mot*";
-                        }
-                        $this->_ta_bind[$this->_count_bind]['field'] = $ta_search['field'];
-                        $this->_ta_bind[$this->_count_bind]['value'] = $match;
-                        $maWhere = "MATCH({$ta_search['table']}.{$ta_search['field']}) AGAINST (:bind" . $this->_count_bind++;
-                        if ($ta_search['operator'] == QueryOperator::FULLTEXT_MATCH_AGAINST_BOOLEAN->value) {
-                            $maWhere .= ' IN BOOLEAN MODE';
-                        }
-                        $maWhere .= ')';
-                        $ta_where[] = $maWhere;
-                    }
                 } else {
                     $this->_ta_bind[$this->_count_bind] = [];
                     $this->_ta_bind[$this->_count_bind]['table'] = $ta_search['table'];
@@ -1514,13 +1462,8 @@
             if (array_key_exists('subRequest', $arg) && is_array($arg['subRequest']) && count($arg['subRequest'])) {
                 foreach ($arg['subRequest'] as $ta_subRequest) {
                     if (!array_key_exists($ta_subRequest['table'], $ta_tables)) {
-                        $table = preg_replace('/ /', '', ucwords(preg_replace('/_/', ' ', $ta_subRequest['table'])));
-                        $classe = 'src\manager\\' . $table . 'Manager';
-                        //$classe = 'src\manager\\' . $ta_subRequest['table'].'Manager';
-                        $obj = new $classe();
-                        $obj->recordFields();
+                        $this->recordTableField($ta_subRequest['table']);
                         $ta_tables = $this->fieldsList();
-                        unset($obj);
                     }
                     if (!array_key_exists($ta_subRequest['field'], $ta_tables[$ta_subRequest['table']])) {
                         trigger_error('Le champ : ' . $ta_subRequest['field'] . ' est introuvable dans la table : ' . $ta_subRequest['table'], E_USER_ERROR);
@@ -1580,12 +1523,8 @@
                 $count = 0;
                 foreach ($arg['groupBy'] as $ta_groupBy) {
                     if (!array_key_exists($ta_groupBy['table'], $ta_tables)) {
-                        $table = preg_replace('/ /', '', ucwords(preg_replace('/_/', ' ', $ta_groupBy['table'])));
-                        $classe = 'src\manager\\' . $table . 'Manager';
-                        $obj = new $classe();
-                        $obj->recordFields();
+                        $this->recordTableField($ta_groupBy['table']);
                         $ta_tables = $this->fieldsList();
-                        unset($obj);
                     }
                     if (!array_key_exists($ta_groupBy['field'], $ta_tables[$ta_groupBy['table']])) {
                         trigger_error('Le champ : ' . $ta_groupBy['field'] . ' est introuvable dans la table : ' . $ta_groupBy['table'], E_USER_ERROR);
@@ -1604,12 +1543,8 @@
                         $count = 0;
                         foreach ($arg['sort'] as $ta_sort) {
                             if (!array_key_exists($ta_sort['table'], $ta_tables)) {
-                                $table = preg_replace('/ /', '', ucwords(preg_replace('/_/', ' ', $ta_sort['table'])));
-                                $classe = 'src\manager\\' . $table . 'Manager';
-                                $obj = new $classe();
-                                $obj->recordFields();
+                                $this->recordTableField($ta_sort['table']);
                                 $ta_tables = $this->fieldsList();
-                                unset($obj);
                             }
                             
                             // Si le champ est chiffré et qu'il a une colonne de tri, elle est utilisée
@@ -1933,6 +1868,44 @@
             } finally {
                 $this->db = $previousDb;
             }
+        }
+        
+        /**
+         * Depuis un nom de table cherche un Manager puis renseigne la liste des champs de la table dans le Manager.
+         *
+         * @param string $table
+         *
+         * @return void
+         *
+         * @throws ManagerNotFoundException
+         */
+        private function recordTableField(string $table): void
+        {
+            $table = preg_replace('/ /', '', ucwords(preg_replace('/_/', ' ', $table)));
+            $classe = 'src\manager\\' . $table . 'Manager';
+            
+            try {
+                if (!class_exists($classe)) {
+                    throw new ManagerNotFoundException("La classe '$classe' n'est pas un Manager valide.");
+                }
+            } catch (Throwable) {
+                throw new ManagerNotFoundException("La classe '$classe' n'est pas un Manager valide.");
+            }
+            
+            $obj = new $classe();
+            
+            if (!$obj instanceof Manager) {
+                throw new ManagerNotFoundException("La classe '$classe' n'est pas un Manager valide.");
+            }
+            
+            // On vérifie si ça n'a pas encore été chargé
+            if (isset(self::$_fieldsList[$this->tableName()])) {
+                unset($obj);
+                return;
+            }
+            
+            $obj->recordFields();
+            unset($obj);
         }
     }
     

--- a/Model.php
+++ b/Model.php
@@ -181,21 +181,6 @@
                             }
                             break;
                         
-                        case 'Date':
-                            if (!($value instanceof DateTime)) {
-                                try {
-                                    if (is_numeric($value) && (int)$value == $value && $value >= 0) {
-                                        $value = (new DateTime())->setTimestamp((int)$value);
-                                    } else {
-                                        $value = new DateTime($value);
-                                    }
-                                } catch (Exception) {
-                                    throw new InvalidArgumentException("La valeur pour {$name} n'est pas une date valide.");
-                                }
-                            }
-                            $value = $value->format('Y-m-d'); // Convertir en date
-                            break;
-                        
                         case 'array':
                             if (!(is_array($value))) {
                                 $value = json_decode($value, true);

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -3,12 +3,13 @@
     namespace processid\manager;
     
     use Exception;
-    use include\common\lib\vendor\processid\manager\exception\ManagerNotFoundException;
     use InvalidArgumentException;
     use LogicException;
     use processid\manager\enum\QueryFunction;
     use processid\manager\enum\QueryOperator;
     use processid\manager\enum\QuerySequenceType;
+    use processid\manager\exception\ManagerNotFoundException;
+    use Throwable;
     
     /**
      * Class QueryBuilder
@@ -559,20 +560,24 @@
             if (is_object($table)) {
                 if (!($table instanceof Manager)) {
                     // Si c'est déjà un manager, on le retourne tel quel
-                    throw new ManagerNotFoundException("La classe '$table' n'est pas un Manager valide.");
+                    throw new ManagerNotFoundException("La classe '" . get_class($table) . "' n'est pas un Manager valide.");
                 }
                 
                 return $table;
             }
             
-            if (class_exists($table)) {
-                // Si c'est une classe valide, on vérifie si c'est un Manager
-                $manager = new $table();
-                if (!$manager instanceof Manager) {
-                    throw new ManagerNotFoundException("La classe '$table' n'est pas un Manager valide.");
+            try {
+                if (class_exists($table)) {
+                    // Si c'est une classe valide, on vérifie si c'est un Manager
+                    $manager = new $table();
+                    if (!$manager instanceof Manager) {
+                        throw new ManagerNotFoundException("La classe '$table' n'est pas un Manager valide.");
+                    }
+                    
+                    return $manager;
                 }
-                
-                return $manager;
+            } catch (Throwable) {
+                throw new ManagerNotFoundException("La classe '$table' n'est pas un Manager valide.");
             }
             
             if (str_contains($table, '\\') || preg_match('/^[A-Z]/', $table)) {

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,11 @@
 {
     "name": "processid/manager",
     "description": "Database management",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "require": {
         "php": ">=8.3",
         "processid/encrypt": "1.*",
+        "processid/traits": "1.*",
         "ext-pdo": "*"
     },
     "autoload": {

--- a/unit/QueryBuilderTest.php
+++ b/unit/QueryBuilderTest.php
@@ -5,6 +5,7 @@
     // Require des fichiers requis
     require_once __DIR__ . '/TestUnit.php';
     
+    use Closure;
     use Exception;
     use LogicException;
     use processid\manager\ConnectionManager;
@@ -47,8 +48,10 @@
          *
          * @return void
          */
-        public function testRun(array $results, int $count, string $name): void
+        public function testRun(Closure $fct, int $count, string $name): void
         {
+            $results = $fct();
+            
             $this->assertCount($count, $results);
             $this->assertEquals($name, $results[0]->getName());
         }
@@ -85,41 +88,41 @@
             
             return [
                 'Single Condition' => [
-                    (new QueryBuilder(new UsersManager()))
+                    fn() => ((new QueryBuilder(new UsersManager()))
                         ->field('id')
                         ->field('name')
                         ->search('id', 1)
                         ->limit(10)
-                        ->run(),
+                        ->run()),
                     1,
                     'Alice'
                 ],
                 'Multiple Conditions' => [
-                    (new QueryBuilder(new UsersManager()))
+                    fn() => ((new QueryBuilder(new UsersManager()))
                         ->field('id')
                         ->field('name')
                         ->search('status', 'active')
                         ->search('email', '@example.com', QueryOperator::LIKE_BOTH)
                         ->sort('id', true)
                         ->limit(10)
-                        ->run(),
+                        ->run()),
                     2,
                     'Diana'
                 ],
                 'Limit and Pagination' => [
-                    (new QueryBuilder(new UsersManager()))
+                    fn() => ((new QueryBuilder(new UsersManager()))
                         ->field('id')
                         ->field('name')
                         ->search('status', 'active')
                         ->limit(1)
                         ->sort('id', true)
-                        ->run(),
+                        ->run()),
                     1,
                     'Diana'
                 ],
                 'Test With Complex Condition' => [
                     // SELECT id, name FROM users WHERE status = 'inactive' OR (name = 'Charlie' OR status = 'pending') ORDER BY id ASC
-                    (new QueryBuilder(new UsersManager()))
+                    fn() => (new QueryBuilder(new UsersManager()))
                         ->field('id')
                         ->field('name')
                         ->search('status', 'inactive')


### PR DESCRIPTION
## Summary

Corrections de bugs identifies lors de la revue de code post-v3.0.0.

- Validation du chargement dynamique de classes (class_exists + instanceof Manager + ManagerNotFoundException)
- Correction du use casse dans QueryBuilder, restauration de processid/traits
- Suppression du double execute() dans countBy
- Restauration du support utf8mb4 configurable + COLLATE dans DbConnect
- Suppression du bloc FULLTEXT duplique dans Manager
- Initialisation de errorTxt = null (propriete typee PHP 8)

## Fichiers modifies

- Manager.php - corrections principales (countBy, FULLTEXT, errorTxt, whitelist classes)
- QueryBuilder.php - use statements, return types, initialisation proprietes
- DbConnect.php - charset configurable + COLLATE
- composer.json - restauration dependance processid/traits
- Model.php - nettoyage type Date supprime
- unit/QueryBuilderTest.php - adaptation tests

## Test plan

- [x] Revue de code validee
- [ ] Tests en cours sur payboxmail